### PR TITLE
Fix TinyColor path

### DIFF
--- a/valo-config.html
+++ b/valo-config.html
@@ -1,6 +1,6 @@
 <link rel="import" href="../polymer/polymer-element.html">
 <link rel="import" href="../polymer/lib/elements/dom-repeat.html">
-<script src="../tinycolor/tinycolor.js"></script>
+<script src="../TinyColor/tinycolor.js"></script>
 
 <dom-module id="valo-config">
   <template>


### PR DESCRIPTION
Seems like some servers/browsers became case-sensitive, so the path to TinyColor must respect that.

Fixes #8.