### PR TITLE
Use rem instead of px for font-size

### DIFF
--- a/typography.html
+++ b/typography.html
@@ -7,13 +7,13 @@
       --valo-font-family: -apple-system, BlinkMacSystemFont, "Roboto", "Segoe UI", Ubuntu, Helvetica, Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol";
 
       /* Font sizes */
-      --valo-font-size-xxxl: 36px;
-      --valo-font-size-xxl: 28px;
-      --valo-font-size-xl: 22px;
-      --valo-font-size-l: 18px;
-      --valo-font-size-m: 16px;
-      --valo-font-size-s: 14px;
-      --valo-font-size-xs: 13px;
+      --valo-font-size-xxxl: 2.25rem;
+      --valo-font-size-xxl: 1.75rem;
+      --valo-font-size-xl: 1.375rem;
+      --valo-font-size-l: 1.125rem;
+      --valo-font-size-m: 1rem;
+      --valo-font-size-s: .875rem;
+      --valo-font-size-xs: .8125rem;
 
       /* Line heights */
       --valo-line-height: 1.625;


### PR DESCRIPTION
Fixes #16

![recorded](https://user-images.githubusercontent.com/6059356/31340109-d23560f8-ad0d-11e7-98e4-b9a95f31d930.gif)


<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-valo-theme/17)
<!-- Reviewable:end -->
