### PR TITLE
Workaround mask-image CSS property to prevent crash in Edge

### DIFF
--- a/mixins/menu-overlay.html
+++ b/mixins/menu-overlay.html
@@ -51,9 +51,12 @@
           left: 0;
           background-color: inherit;
           background-image: inherit;
-          --_valo-menu-overlay-mask-image: linear-gradient(#000, transparent 40px, transparent calc(100% - 40px), #000);
-          -webkit-mask-image: var(--_valo-menu-overlay-mask-image);
-          mask-image: var(--_valo-menu-overlay-mask-image);
+          /*
+            TODO: CSS custom property in `mask-image` causes crash in Edge
+            see https://developer.microsoft.com/en-us/microsoft-edge/platform/issues/15415089/
+          */
+          -webkit-mask-image: linear-gradient(#000, transparent 40px, transparent calc(100% - 40px), #000);
+          mask-image: linear-gradient(#000, transparent 40px, transparent calc(100% - 40px), #000);
         }
       }
 


### PR DESCRIPTION
Fixes #45

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-valo-styles/48)
<!-- Reviewable:end -->
